### PR TITLE
refs #1 use http basic auth instead of auth_any

### DIFF
--- a/lib/BrandedCrate/PayJunction/Client.php
+++ b/lib/BrandedCrate/PayJunction/Client.php
@@ -66,7 +66,7 @@ class Client
         curl_setopt($this->curl, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->curl, CURLOPT_FORBID_REUSE, true);
-        curl_setopt($this->curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+        curl_setopt($this->curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         curl_setopt($this->curl, CURLOPT_USERPWD, $this->options['username'] . ":" . $this->options['password']);
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, array(
             "X-PJ-Application-Key: {$this->options['appkey']}",


### PR DESCRIPTION
auth_any works by making two HTTP requests where the first one only
checks the response headers to find the right auth method to use.
Switching to basic auth results in fewer API calls which helps avoid the
rate limitations
