### PR TITLE
Add namespace to autoload stanza

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "autoload": {
         "psr-0": {
-            "": "lib"
+            "BrandedCrate\\PayJunction": "lib"
         }
     }
 }


### PR DESCRIPTION
This is causing autoload_namespace.php to be missing the namespace key for PayJunction.
